### PR TITLE
perf: use static one-shot hash APIs on NET7+

### DIFF
--- a/Benchmarks/InternalBenchmarks.cs
+++ b/Benchmarks/InternalBenchmarks.cs
@@ -1,0 +1,37 @@
+using BenchmarkDotNet.Attributes;
+using DeterministicGuids;
+
+namespace Benchmarks;
+
+/// <summary>
+/// Benchmarks covering all three UUID versions (v3/MD5, v5/SHA-1, v8/SHA-256)
+/// and two name lengths (short stackalloc path, long heap-fallback path).
+/// Useful for regression detection across code paths within DeterministicGuids itself.
+/// </summary>
+[MemoryDiagnoser]
+public class InternalBenchmarks
+{
+    // Short: well under the stackalloc threshold (10 bytes UTF-8)
+    private const string ShortName = "python.org";
+
+    // Long: exceeds the 496-byte stackalloc threshold on NET8+ (512 on NET5-7),
+    // exercises the heap-allocation fallback path
+    private const string LongName =
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut " +
+        "labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco " +
+        "laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in " +
+        "voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat " +
+        "non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis " +
+        "unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.";
+
+    private static readonly Guid Ns = DeterministicGuid.Namespaces.Dns;
+
+    [Params(DeterministicGuid.Version.MD5, DeterministicGuid.Version.SHA1, DeterministicGuid.Version.SHA256)]
+    public DeterministicGuid.Version Version { get; set; }
+
+    [Benchmark(Baseline = true)]
+    public Guid Short_Name() => DeterministicGuid.Create(Ns, ShortName, Version);
+
+    [Benchmark]
+    public Guid Long_Name() => DeterministicGuid.Create(Ns, LongName, Version);
+}

--- a/DeterministicGuids/DeterministicGuid.cs
+++ b/DeterministicGuids/DeterministicGuid.cs
@@ -202,21 +202,33 @@ namespace DeterministicGuids
             if (version == Version.SHA1)
             {
                 Span<byte> hashBuf = stackalloc byte[20];
+#if NET7_0_OR_GREATER
+                SHA1.HashData(concat, hashBuf);
+#else
                 Sha1Tls.Value!.TryComputeHash(concat, hashBuf, out _);
+#endif
                 hashBuf[..16].CopyTo(uuidBe);
                 uuidBe[6] = (byte)((uuidBe[6] & 0x0F) | (5 << 4));
             }
             else if (version == Version.SHA256)
             {
                 Span<byte> hashBuf = stackalloc byte[32];
+#if NET7_0_OR_GREATER
+                SHA256.HashData(concat, hashBuf);
+#else
                 Sha256Tls.Value!.TryComputeHash(concat, hashBuf, out _);
+#endif
                 hashBuf[..16].CopyTo(uuidBe);
                 uuidBe[6] = (byte)((uuidBe[6] & 0x0F) | (8 << 4));
             }
             else // MD5
             {
                 Span<byte> hashBuf = stackalloc byte[16];
+#if NET7_0_OR_GREATER
+                MD5.HashData(concat, hashBuf);
+#else
                 Md5Tls.Value!.TryComputeHash(concat, hashBuf, out _);
+#endif
                 hashBuf.CopyTo(uuidBe);
                 uuidBe[6] = (byte)((uuidBe[6] & 0x0F) | (3 << 4));
             }
@@ -425,11 +437,13 @@ namespace DeterministicGuids
         }
 #endif
 
+#if !NET7_0_OR_GREATER
         // Thread-local hashers:
         // We keep one MD5, one SHA-1 and one SHA-256 per thread so we don't allocate HashAlgorithm
         // objects per call.
         private static readonly ThreadLocal<HashAlgorithm> Sha1Tls = new(SHA1.Create);
         private static readonly ThreadLocal<HashAlgorithm> Md5Tls = new(MD5.Create);
         private static readonly ThreadLocal<HashAlgorithm> Sha256Tls = new(SHA256.Create);
+#endif
     }
 }


### PR DESCRIPTION
## Summary

On .NET 7+, replace `ThreadLocal<HashAlgorithm>` + `TryComputeHash` with the static one-shot `SHA1.HashData` `MD5.HashData` `SHA256.HashData` APIs.

- Uses the platform's native one-shot CNG/OpenSSL path
- No public API changes

Closes #17